### PR TITLE
add output_folder option for generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Create a configuration file `schema-generate.yaml` with the following contents:
 	# optionally, map Scalar to your own implementation
 	bindings:
   		Date: CustomDate
+	
+	# optional: provide a folder to output the generated files to.
+	# note - this folder must already exist, path is relative to config
+	# file location
+	# 
+	# trailing slash is required for formatting
+	output_folder: pkg/generated/
 
 ## run
 

--- a/build.go
+++ b/build.go
@@ -14,7 +14,7 @@ var buildSource string
 
 func (g *Generator) handleBuildTools() error {
 
-	out, err := os.Create("build.go")
+	out, err := os.Create(fmt.Sprintf("%sbuild.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/cmd/gcg/main.go
+++ b/cmd/gcg/main.go
@@ -21,6 +21,7 @@ type Config struct {
 	SchemaFile     string            `yaml:"schema"`
 	PackageName    string            `yaml:"package"`
 	ScalarBindings map[string]string `yaml:"bindings"`
+	OutputFolder   string            `yaml:"output_folder"`
 }
 
 func readConfig() *Config {
@@ -39,7 +40,7 @@ func readConfig() *Config {
 		}
 	}
 
-	config := Config{"schema.gql", "generated", map[string]string{}}
+	config := Config{"schema.gql", "generated", map[string]string{}, ""}
 
 	if configFile != "" {
 		// Parse the configuration
@@ -69,7 +70,8 @@ func main() {
 	gen := gcg.NewGenerator(string(data),
 		gcg.WithScalarBindings(config.ScalarBindings),
 		gcg.WithPackage(config.PackageName),
-		gcg.WithSource(config.SchemaFile))
+		gcg.WithSource(config.SchemaFile),
+		gcg.WithOutputFolder(config.OutputFolder))
 
 	err = gen.Generate()
 	if err != nil {

--- a/enums.go
+++ b/enums.go
@@ -1,6 +1,7 @@
 package gcg
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"text/template"
@@ -10,7 +11,7 @@ import (
 
 func (g *Generator) handleEnums(all []*ast.Definition) error {
 	log.Println("generating enums.go")
-	out, err := os.Create("enums.go")
+	out, err := os.Create(fmt.Sprintf("%senums.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/functions.go
+++ b/functions.go
@@ -21,7 +21,7 @@ type Function struct {
 
 func (g *Generator) handleFunctions() error {
 	log.Println("generating functions.go")
-	out, err := os.Create("functions.go")
+	out, err := os.Create(fmt.Sprintf("%sfunctions.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/generator.go
+++ b/generator.go
@@ -25,6 +25,7 @@ type Generator struct {
 	scalarBindings []ScalarBinding
 	mainVersion    string
 	schemaVersion  string
+	outputFolder   string
 }
 
 func NewGenerator(schemaSource string, options ...Option) *Generator {

--- a/inputs.go
+++ b/inputs.go
@@ -1,6 +1,7 @@
 package gcg
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"text/template"
@@ -10,7 +11,7 @@ import (
 
 func (g *Generator) handleInputs(doc *ast.SchemaDocument, all []*ast.Definition) error {
 	log.Println("generating inputs.go")
-	out, err := os.Create("inputs.go")
+	out, err := os.Create(fmt.Sprintf("%sinputs.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/mutations.go
+++ b/mutations.go
@@ -14,7 +14,7 @@ import (
 
 func (g *Generator) handleMutations(each *ast.Definition) error {
 	log.Println("generating mutations.go")
-	out, err := os.Create("mutations.go")
+	out, err := os.Create(fmt.Sprintf("%smutations.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/option.go
+++ b/option.go
@@ -22,3 +22,9 @@ func WithSource(filename string) func(*Generator) {
 		g.sourceFilename = filename
 	}
 }
+
+func WithOutputFolder(path string) func(*Generator) {
+	return func(g *Generator) {
+		g.outputFolder = path
+	}
+}

--- a/queries.go
+++ b/queries.go
@@ -13,7 +13,7 @@ import (
 
 func (g *Generator) handleQueries(def *ast.Definition) error {
 	log.Println("generating queries.go")
-	out, err := os.Create("queries.go")
+	out, err := os.Create(fmt.Sprintf("%squeries.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/scalars.go
+++ b/scalars.go
@@ -1,6 +1,7 @@
 package gcg
 
 import (
+	"fmt"
 	"os"
 	"text/template"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func (g *Generator) handleScalars(all []*ast.Definition) error {
-	out, err := os.Create("scalars.go")
+	out, err := os.Create(fmt.Sprintf("%sscalars.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/types.go
+++ b/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (g *Generator) handleTypes(doc *ast.SchemaDocument) error {
-	out, err := os.Create("types.go")
+	out, err := os.Create(fmt.Sprintf("%stypes.go", g.outputFolder))
 	if err != nil {
 		return err
 	}

--- a/unions.go
+++ b/unions.go
@@ -1,6 +1,7 @@
 package gcg
 
 import (
+	"fmt"
 	"os"
 	"text/template"
 
@@ -14,7 +15,7 @@ and that the included types do not need to share any fields.
 **/
 
 func (g *Generator) handleUnions(doc *ast.SchemaDocument, all []*ast.Definition) error {
-	out, err := os.Create("unions.go")
+	out, err := os.Create(fmt.Sprintf("%sunions.go", g.outputFolder))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds an optional `output_folder` to the config file to describe where you would like to place generated files.

It requires the folder already exist and include a trailing slash so that a `fmt.Sprintf("%sfilename", g.outputFolder)` is a valid path.